### PR TITLE
[feature] Support for heterogenerous camera calibrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Run on a dataset from [http://www.cvlibs.net/datasets/kitti/eval_odometry.php](h
 
 		bin/dso_dataset \
 			files=XXXXX/sequence_XX \
-			calib=XXXXX/sequence_XX/para/camera.txt \
+			calib_l=XXXXX/sequence_XX/para/camera_l.txt \
+			calib_r=XXXXX/sequence_XX/para/camera_r.txt \
 			gamma=XXXXX/sequence_XX/para/pcalib.txt \
 			vignette=XXXXX/sequence_XX/para/vignette.png \
 			preset=0 \
@@ -26,7 +27,8 @@ Under sequence_XX, there should be two image datasets called image_0 and image_1
 
 		bin/dso_dataset \
 			files=XXXXX/sequence_XX \
-			calib=XXXXX/sequence_XX/para/camera.txt \
+			calib_l=XXXXX/sequence_XX/para/camera_l.txt \
+			calib_r=XXXXX/sequence_XX/para/camera_r.txt \
 			preset=0 \
 			mode=1
 #### 2.1 Dataset Format

--- a/src/main_dso_pangolin.cpp
+++ b/src/main_dso_pangolin.cpp
@@ -52,7 +52,8 @@
 std::string vignette = "";
 std::string gammaCalib = "";
 std::string source = "";
-std::string calib = "";
+std::string calib_l = "";
+std::string calib_r = "";
 double rescale = 1;
 bool reverse = false;
 bool disableROS = false;
@@ -245,9 +246,17 @@ void parseArgument(char *arg) {
     return;
   }
 
-  if (1 == sscanf(arg, "calib=%s", buf)) {
-    calib = buf;
-    printf("loading calibration from %s!\n", calib.c_str());
+  if (1 == sscanf(arg, "calib_l=%s", buf)) {
+    calib_l = buf;
+    printf("loading calibration for the left camera from %s!\n",
+           calib_l.c_str());
+    return;
+  }
+
+  if (1 == sscanf(arg, "calib_r=%s", buf)) {
+    calib_r = buf;
+    printf("loading calibration for the right camera from %s!\n",
+           calib_r.c_str());
     return;
   }
 
@@ -331,9 +340,9 @@ int main(int argc, char **argv) {
   std::thread exThread = std::thread(exitThread);
 
   ImageFolderReader *reader =
-      new ImageFolderReader(source + "/image_0", calib, gammaCalib, vignette);
+      new ImageFolderReader(source + "/image_0", calib_l, gammaCalib, vignette);
   ImageFolderReader *reader_right =
-      new ImageFolderReader(source + "/image_1", calib, gammaCalib, vignette);
+      new ImageFolderReader(source + "/image_1", calib_r, gammaCalib, vignette);
   reader->setGlobalCalibration();
   reader_right->setGlobalCalibration();
 


### PR DESCRIPTION
Add support for heterogeneous camera calibrations by adding command line options
- remove `calib` option
- add `calib_l` and `calib_r` options