### PR TITLE
[fix] Depth image output wrapper outputs TIFF instead of PNG

### DIFF
--- a/src/IOWrapper/OpenCV/DepthImageWrapper.cpp
+++ b/src/IOWrapper/OpenCV/DepthImageWrapper.cpp
@@ -44,9 +44,9 @@ DepthImageWrapper::~DepthImageWrapper() noexcept {
 
 void DepthImageWrapper::pushDepthImageFloat(MinimalImageF *image,
                                             FrameHessian *KF) {
-  std::string basename(16, '\0');
-  std::size_t str_len =
-      std::snprintf(basename.data(), basename.size() - 1, "%010zu.png", count_);
+  std::string basename(17, '\0');
+  std::size_t str_len = std::snprintf(basename.data(), basename.size() - 1,
+                                      "%010zu.tiff", count_);
   basename.resize(str_len);
   std::string filename = (output_directory_ / basename).string();
 

--- a/src/main_dso_pangolin.cpp
+++ b/src/main_dso_pangolin.cpp
@@ -374,8 +374,11 @@ int main(int argc, char **argv) {
     viewer = new IOWrap::PangolinDSOViewer(wG[0], hG[0], false);
     fullSystem->outputWrapper.push_back(viewer);
   }
-  fullSystem->outputWrapper.push_back(new IOWrap::DepthImageWrapper(
-      depthImageOutput, std::filesystem::path(depthImageOutput) / "times.txt"));
+  if (!depthImageOutput.empty()) {
+    fullSystem->outputWrapper.push_back(new IOWrap::DepthImageWrapper(
+        depthImageOutput,
+        std::filesystem::path(depthImageOutput) / "times.txt"));
+  }
 
   if (useSampleOutput)
     fullSystem->outputWrapper.push_back(new IOWrap::SampleOutputWrapper());


### PR DESCRIPTION
- float32 depth image output format is changed from PNG to TIFF
- Depth image output is now disabled when the option is not passed